### PR TITLE
Update mirrors

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,13 +202,13 @@ This is your character encoding. Default value is `"UTF-8"`.  You can also selec
 #####"mirror" option
 Select the default mirror to which japaneasy sends requests. The default value is `"usa"`. Other values include:
 `"sweden"`
-`"japan"`
 `"germany"`
 `"canada"`
-`"austrailia"`
+`"australia_monash"`
+`"australia_melbourne"`
 
 #####"timeout" option
-If a request to a certain has not resolved the promise object within the time specified here, japaneasy will query a different mirror.  WWWJDIC mirrors occasionally go down (at the time of this writing, the Austrailia mirror is down), but it's very infrequent that all five are down at the same time. 
+If a request to a certain has not resolved the promise object within the time specified here, japaneasy will query a different mirror.  WWWJDIC mirrors occasionally go down, but it's very infrequent that all five are down at the same time.
 Default value is `500` (milliseconds), which is long enough to not query multiple mirrors and short enough to not notice the delay if you switch over. If you're consistently seeing long load times, try changing the default mirror. 
 
 #####"custom" option

--- a/index.js
+++ b/index.js
@@ -87,10 +87,10 @@ var dic = function (config) {
 
   function mapMirror(key) {
     var map = {
-      "austrailia": "http://www.csse.monash.edu.au/~jwb/cgi-bin/wwwjdic?",
-      "canada": "http://www.ottix.net/cgi-bin/wwwjdic/wwwjdic?",
+      "austrailia": "http://nihongo.monash.edu/cgi-bin/wwwjdic?",
+      "australia_monash": "http://nihongo.monash.edu/cgi-bin/wwwjdic?",
+      "australia_melbourne": "http://nlp.cis.unimelb.edu.au/jwb/wwwjdic/wwwjdic.cgi?",
       "germany": "http://wwwjdic.biz/cgi-bin/wwwjdic?",
-      "japan": "http://gengo.com/wwwjdic/cgi-data/wwwjdic?",
       "usa": "http://www.edrdg.org/cgi-bin/wwwjdic/wwwjdic?",
       "sweden": "http://wwwjdic.se/cgi-bin/wwwjdic?"
     }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "japaneasy",
   "description": "API for the WWWJDICT project",
   "author": "Rewon Child <rewonc@gmail.com> (https://github.com/rewonc)",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "main": "index.js",
   "scripts": {
     "test": "mocha"


### PR DESCRIPTION
Hi,

This PR updates the mirror list based on the current info at: https://www.edrdg.org/wwwjdic/wwwjdicmirrors.html

In summary:

1. The Japan mirror has been removed. It actually still responds, but it always returns an empty result, and it is no longer listed as an official mirror.
2. The Canada mirror has been removed. It doesn't respond at all and it is no longer listed as an official mirror.
2. There are now two Australian mirrors. I added them as `australia_monash` and `australia_melbourne`. I left `austrailia` for backwards compatibility and updated it to point to the monash mirror (the previous address 302 redirects there).